### PR TITLE
Added errors length check.

### DIFF
--- a/lib/formula.rb
+++ b/lib/formula.rb
@@ -353,7 +353,7 @@ module Formula
     
     def error(method)
       errors = @object.errors[method] if @object
-      errors.to_sentence unless errors.blank?
+      errors.to_sentence if errors.present?
     end
     
     


### PR DESCRIPTION
By default MongoId returns empty errors array for any field. That's results in creation of empty error divs.
