### PR TITLE
CSS class assignment improvements.

### DIFF
--- a/lib/formula.rb
+++ b/lib/formula.rb
@@ -187,6 +187,8 @@ module Formula
       options[:as] ||= as(method)
       options[:input] ||= {}
       
+      return hidden_field method, options[:input] if options[:as] == :hidden
+      
       self.block(method, options) do
         @template.content_tag(::Formula.input_tag, :class => [::Formula.input_class, options[:as]]) do
           case options[:as]
@@ -194,7 +196,6 @@ module Formula
             when :file     then file_field      method, options[:input]
             when :string   then text_field      method, options[:input]
             when :password then password_field  method, options[:input]
-            when :hidden   then hidden_field    method, options[:input]
             when :boolean  then check_box       method, options[:input]
             when :url      then url_field       method, options[:input]
             when :email    then email_field     method, options[:input]

--- a/test/dummy/app/models/contact.rb
+++ b/test/dummy/app/models/contact.rb
@@ -1,5 +1,7 @@
 class Contact < ActiveRecord::Base
   
+  attr_accessor :hidden_field
+  
   belongs_to :group
   
   validates_presence_of :name

--- a/test/dummy/app/views/contacts/_form.html.erb
+++ b/test/dummy/app/views/contacts/_form.html.erb
@@ -13,7 +13,9 @@
   
   <%= form.association :group, Group.all, :id, :name, :container => { :class => 'grid-12' }, 
     :association => { :prompt => "-- Group --", :html => { :class => 'group' } } %>
-    
+  
+  <%= form.input :hidden_field, :as => :hidden %> 
+   
   <%= form.button 'Save', :container => { :class => 'grid-12' } %>
   
 <% end %>

--- a/test/dummy/test/integration/contact_form_test.rb
+++ b/test/dummy/test/integration/contact_form_test.rb
@@ -89,6 +89,9 @@ class ContactFormTest < ActionDispatch::IntegrationTest
     
     assert_select(".block.with_errors", {:count => 6}, 'There should be 7 blocks with "with_errors" class.')
     assert_select('.field_with_errors', false, 'There should be no tags with "field_with_errors" class.')
+    
+    assert_select('#contact_hidden_field', true, 'There should be hidden field')
+    assert_select('.block > #contact_hidden_field', false, 'Hidden field should not be wrapped with block')
   end
   
 end


### PR DESCRIPTION
1. Removed method name from block class.
   This behaviour was not documented.
   
   ``` ruby
   # Usage:
   #
   #   f.input(:name)
   #   ...
   # Equivalent:
   #
   #   <div class="block">
   #   ...
   ```
   
   And more importantly, method names likely would be defined as style classes for non form elements.
2. Replaced default error wrapper with empty.
3. Added block_error_class for blocks with errors.
4. Prevent hidden field from wrapping.  
